### PR TITLE
Fixed NullReferenceException on PlayerCorpses after killing a Birdman

### DIFF
--- a/Mod/Classes/Patched/PlayerCorpse.cs
+++ b/Mod/Classes/Patched/PlayerCorpse.cs
@@ -27,7 +27,10 @@ namespace TowerFall
       orig_ctor(enemyCorpse, position, facing, killerIndex);
 
       this.sprite.FlipX = (this.Facing == Facing.Left) && !IsReverseGrav();
-      this.flashSprite.FlipX = (this.Facing == Facing.Left) && !IsReverseGrav();
+      if (this.flashSprite != null) 
+      {
+        this.flashSprite.FlipX = (this.Facing == Facing.Left) && !IsReverseGrav();
+      }
     }
 
     public extern void orig_DoWrapRender();


### PR DESCRIPTION
Birdman doesn't have a flashSprite, so if it tried to access this variable, it will throw this exception.